### PR TITLE
feat: Add --trash option for safer file moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ sfo undo --manifest ./sfo-manifest.json
 - `init` – write a default config to the OS-appropriate config dir.
 - `dry-run` – print a plan of moves/copies without changing the filesystem.
 - `organize` – execute the plan and produce an undo manifest.
+  - `--on-collision`: What to do if a destination file already exists (`rename` (default), `overwrite`, `skip`).
+  - `--trash PATH`: Stage files in this directory before final move. On failure, the file remains in the trash and is recorded in the manifest.
 - `undo` – revert changes recorded in a manifest file.
 
 ## Configuration (YAML)


### PR DESCRIPTION
This commit introduces a new `--trash` option to the `organize` command. When this option is used, files are first moved to a specified trash directory before being moved to their final destination.

If the final move fails, the file remains in the trash directory, and the failure is recorded in the manifest file. This provides a safety mechanism to prevent file loss during the organization process.

A new test case has been added to simulate a move failure and verify that the file is correctly placed in the trash directory and that the manifest is updated accordingly.

The README.md file has also been updated to document the new option.

# 📌 Pull Request: [Feature/Hotfix Title]

## ✨ Summary

- Describe the feature, bugfix, or refactor in plain language.
- Example: "Implements Rules Engine v1 with support for extension, regex, and mtime."

## ✅ Acceptance Criteria

- [x] Config supports `type: extension|regex|mtime`, `pattern/when`, and `target_template`.
- [x] Planner selects first matching rule; fallback if none.
- [x] `dry-run` and `organize` use rules correctly.
- [x] Destinations match `target_template`.

## 🧪 Test Results

- [x] Unit tests added/updated and passing (`pytest`).
- [x] Manual dry-run tested with sample files.
- [x] CI workflow (Ruff + pytest) passing.

## 📚 Documentation

- [x] Updated `README.md` with new usage.
- [x] Updated `config.example.yml` with rule samples.
- [x] Added/updated architecture or usage diagram if needed.

## 🔗 Related Issues

Closes #(issue-number)

---
⚡ **Checklist for Reviewer**

- Code follows style guide (Ruff, formatting).
- Clear variable/function names.
- Tests cover main paths and edge cases.
- Docs are clear and up-to-date.
